### PR TITLE
Relax collection id requirements

### DIFF
--- a/puzzle_config/src/json.rs
+++ b/puzzle_config/src/json.rs
@@ -1,11 +1,10 @@
 use crate::config::difficulty::PuzzleDifficultyConfig;
 use crate::config::{board, tile};
 use crate::{
-    AreaConfig, AreaValueFormatter, BoardConfig, PuzzleConfig, PuzzleConfigCollection, ReadError,
-    TargetTemplate, TileConfig,
+    validation, AreaConfig, AreaValueFormatter, BoardConfig, PuzzleConfig, PuzzleConfigCollection,
+    ReadError, TargetTemplate, TileConfig,
 };
 use ndarray::Array2;
-use regex::Regex;
 use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -170,7 +169,7 @@ fn convert(puzzle_collection: PuzzleCollection) -> Result<PuzzleConfigCollection
         puzzle_collection.name,
         puzzle_collection.description,
         puzzle_collection.author,
-        validate_collection_id(puzzle_collection.id)?,
+        validation::validate_collection_id(puzzle_collection.id)?,
         puzzle_collection.version,
         puzzle_configs,
     ))
@@ -219,19 +218,6 @@ fn rotate_board(board: BoardConfig) -> BoardConfig {
             }
         }
     }
-}
-
-fn validate_collection_id(id: String) -> Result<String, ReadError> {
-    if id.trim().is_empty() {
-        return Err(ReadError::InvalidCollectionId(id));
-    }
-
-    Regex::new(r"^[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+$")
-        .unwrap()
-        .find(&id)
-        .ok_or(ReadError::InvalidCollectionId(id.clone()))?;
-
-    Ok(id)
 }
 
 fn convert_difficulty(difficulty: &Option<PuzzleDifficulty>) -> Option<PuzzleDifficultyConfig> {

--- a/puzzle_config/src/lib.rs
+++ b/puzzle_config/src/lib.rs
@@ -1,6 +1,7 @@
 mod config;
 mod error;
 mod json;
+mod validation;
 
 pub use config::area::AreaConfig;
 pub use config::area::AreaValueFormatter;

--- a/puzzle_config/src/validation.rs
+++ b/puzzle_config/src/validation.rs
@@ -1,0 +1,61 @@
+use crate::ReadError;
+use regex::Regex;
+
+pub(crate) fn validate_collection_id(id: String) -> Result<String, ReadError> {
+    if id.trim().is_empty() {
+        return Err(ReadError::InvalidCollectionId(id));
+    }
+
+    Regex::new(r"^([a-zA-Z0-9-]+\.)+[a-zA-Z0-9-]+$")
+        .unwrap()
+        .find(&id)
+        .ok_or(ReadError::InvalidCollectionId(id.clone()))?;
+
+    Ok(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_collection_id_valid() {
+        let valid_ids = vec![
+            "com.example.collection",
+            "org.dash-domain.puzzles",
+            "de.til7701.numbers",
+            "de.til7701.long.collection.id.with.many.parts",
+        ];
+
+        for id in valid_ids {
+            assert!(
+                validate_collection_id(id.to_string()).is_ok(),
+                "Expected '{}' to be valid",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_collection_id_invalid() {
+        let invalid_ids = vec![
+            "",
+            "   ",
+            "invalid id",
+            "no-dots-in-this-id",
+            "double..dots..id",
+            ".leadingdot.collection",
+            "trailingdot.collection.",
+            "other@invalid#chars!.collection",
+            "underscore_in_id.collection",
+        ];
+
+        for id in invalid_ids {
+            assert!(
+                validate_collection_id(id.to_string()).is_err(),
+                "Expected '{}' to be invalid",
+                id
+            );
+        }
+    }
+}


### PR DESCRIPTION
A collection id may now have more dots as separators. It must now have at least one and may have as many as fit in a string. Between each dot, the only allowed characters are still `[a-z][A-Z][0-9]-`