### PR TITLE
Fix shortcut dialog

### DIFF
--- a/puzzled/resources/ui/dialog/shortcuts-dialog.ui
+++ b/puzzled/resources/ui/dialog/shortcuts-dialog.ui
@@ -24,13 +24,13 @@
                 <child>
                     <object class="AdwShortcutsItem">
                         <property name="title" translatable="yes" context="shortcut window">Calculate tile combinations to solve</property>
-                        <property name="action-name">app.calculate-tile-combinations-to-solve</property>
+                        <property name="action-name">app.calculate_tile_combinations_to_solve</property>
                     </object>
                 </child>
                 <child>
                     <object class="AdwShortcutsItem">
                         <property name="title" translatable="yes" context="shortcut window">Stop calculating tile combinations to solve</property>
-                        <property name="action-name">app.stop-calculate-tile-combinations-to-solve</property>
+                        <property name="action-name">app.stop_calculate_tile_combinations_to_solve</property>
                     </object>
                 </child>
             </object>


### PR DESCRIPTION
In the latest refactoring the action names changed from dashes to underscores. The shortcut dialog was forgotten.